### PR TITLE
Implement new XML API

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,7 @@ WriteMakefile(
   'PREREQ_PM'    => { 'Carp::Heavy'       => 0,
                       'IO::Socket'        => 0,
                       'MIME::Base64'      => 0,
-		      'HTML::TableParser' => 0
-		    }
+                      'XML::Simple'       => 0
+                    }
 );
 


### PR DESCRIPTION
Unfortunately, this does not (yet) parse the additional hints (plural forms, cases, parts of speech, etc., everything inside the `<repr>` tags) because `XML::Simple` does not retain the correct ordering of `CDATA` content mixed with subtags… :-/

This also removes the options `-SpellTolerance`, `-Morphology`, and `-CharTolerance`, which are no longer supported by the new API (as long as I can see).

To be honest, I'm rather unhappy with the restrictions, but at least I got it working again, with basically no knowledge about the Perl ecosystem… O:-)

(And yes, I only just now saw the warning that XML::Simple is not to be used for new code… well.)